### PR TITLE
Ability to enable dns retry and change dns servers for spf checks

### DIFF
--- a/libs/default_settings.py
+++ b/libs/default_settings.py
@@ -61,11 +61,12 @@ SQL_DB_DRIVER = ''
 # Timeout in seconds. Must be a float number.
 DNS_QUERY_TIMEOUT = 3.0
 
-# Should we retry a nameserver if it says SERVFAIL?
-DNS_QUERY_RETRY = False
-
 # List of dns servers to use (if we don't use system configuration)
 DNS_NAMESERVERS = []
+
+# Should we retry a nameserver if it says SERVFAIL?
+# works only if we have set DNS_NAMESERVERS
+DNS_QUERY_RETRY_IF_SERVFAIL = False
 
 # Log smtp actions returned by plugins in SQL database (table `smtp_actions`).
 LOG_SMTP_SESSIONS = True

--- a/libs/default_settings.py
+++ b/libs/default_settings.py
@@ -61,6 +61,12 @@ SQL_DB_DRIVER = ''
 # Timeout in seconds. Must be a float number.
 DNS_QUERY_TIMEOUT = 3.0
 
+# Should we retry a nameserver if it says SERVFAIL?
+DNS_QUERY_RETRY = False
+
+# List of dns servers to use (if we don't use system configuration)
+DNS_NAMESERVERS = []
+
 # Log smtp actions returned by plugins in SQL database (table `smtp_actions`).
 LOG_SMTP_SESSIONS = True
 LOG_SMTP_SESSIONS_EXPIRE_DAYS = 7

--- a/libs/dnsspf.py
+++ b/libs/dnsspf.py
@@ -12,6 +12,7 @@ resv.lifetime = settings.DNS_QUERY_TIMEOUT
 if settings.DNS_NAMESERVERS:
     resv.nameservers = settings.DNS_NAMESERVERS
     resv.retry_servfail = settings.DNS_QUERY_RETRY_IF_SERVFAIL
+    resv.timeout = settings.DNS_QUERY_TIMEOUT / len(settings.DNS_NAMESERVERS)
 
 
 def query_a(domains, queried_domains=None, returned_ips=None):

--- a/libs/dnsspf.py
+++ b/libs/dnsspf.py
@@ -9,6 +9,9 @@ import settings
 resv = resolver.Resolver()
 resv.timeout = settings.DNS_QUERY_TIMEOUT
 resv.lifetime = settings.DNS_QUERY_TIMEOUT
+resv.retry_servfail = settings.DNS_QUERY_RETRY
+if settings.DNS_NAMESERVERS:
+    resv.nameservers = settings.DNS_NAMESERVERS
 
 
 def query_a(domains, queried_domains=None, returned_ips=None):

--- a/libs/dnsspf.py
+++ b/libs/dnsspf.py
@@ -9,9 +9,9 @@ import settings
 resv = resolver.Resolver()
 resv.timeout = settings.DNS_QUERY_TIMEOUT
 resv.lifetime = settings.DNS_QUERY_TIMEOUT
-resv.retry_servfail = settings.DNS_QUERY_RETRY
 if settings.DNS_NAMESERVERS:
     resv.nameservers = settings.DNS_NAMESERVERS
+    resv.retry_servfail = settings.DNS_QUERY_RETRY_IF_SERVFAIL
 
 
 def query_a(domains, queried_domains=None, returned_ips=None):


### PR DESCRIPTION
We need ability to use different servers for spf checks.

Could I ask for including this in upstream?  If administrator doesn't set option in settings, nothing changes. 

I have set `DNS_QUERY_RETRY` to `False`, as this is default setting for dns module.
