### PR TITLE
fix throttle tracking was not being reset

### DIFF
--- a/plugins/throttle.py
+++ b/plugins/throttle.py
@@ -595,6 +595,7 @@ def apply_throttle(conn,
     # {tracking_id: ['last_time=xxx', 'init_time=xxx', ...]}
     sql_updates = {}
 
+    tracking_expired = False
     for (_, v) in list(t_settings.items()):
         tid = v['tid']
         for k in v['track_key']:
@@ -610,10 +611,11 @@ def apply_throttle(conn,
                 sql_updates[tracking_id]['last_time'] = now
 
                 if v['expired']:
+                    tracking_expired = True
                     sql_updates[tracking_id]['init_time'] = now
                     sql_updates[tracking_id]['cur_msgs'] = recipient_count
                     sql_updates[tracking_id]['cur_quota'] = size
-                else:
+                elif not tracking_expired:
                     sql_updates[tracking_id]['init_time'] = v['init_time']
                     sql_updates[tracking_id]['cur_msgs'] = 'cur_msgs + %d' % recipient_count
                     sql_updates[tracking_id]['cur_quota'] = 'cur_quota + %d' % size


### PR DESCRIPTION
The throttle plugin has several checks (t_settings):
msg_size, max_rcpts, max_msgs, and max_quota.

Each of them keeps track of whether the throttle_tracking should be reset (setting init_time = now). The problem is that if any of these checks have an 'expired' value of True, but if any consequent checks have an 'expired' value of False the throttle_tracking is never restarted.

This means that a user can exceed the limits established in the throttle. Due to the time (_period + now) will always be greater than (_init_time + _period) therefore in the case of max_msgs, _cur_msgs will always be 0, and this will allow the number of messages to be infinite.