### PR TITLE
Update iRedAPD logrotate postrotate action to prevent generating errors

### DIFF
--- a/samples/logrotate.d/iredapd
+++ b/samples/logrotate.d/iredapd
@@ -8,6 +8,6 @@
     sharedscripts
 
     postrotate
-        /usr/sbin/service rsyslog restart
+        /usr/bin/systemctl -s HUP kill rsyslog.service >/dev/null 2>&1 || true
     endscript
 }


### PR DESCRIPTION
Related to https://github.com/iredmail/iRedAPD/issues/17 - using /usr/sbin/service is deprecated on all Linux distributions currently supported by iRedAPD and is generating error messages.

This change has been tested on: Ubuntu 22.04.3, RHEL 8.8, Debian 12.1