### PR TITLE
Fixed: a split SPF TXT record can start with space letter

### DIFF
--- a/libs/dnsspf.py
+++ b/libs/dnsspf.py
@@ -136,9 +136,9 @@ def query_spf(domain, queried_domains=None, num_queries=0):
 
             # Some SPF records contains splited IP address like below:
             #   v=spf1 ... ip4:66.220.157" ".0/25 ...
-            # We should remove '"' and combine them.
-            _v = [v for v in r.split('"') if not v.startswith(' ')]
-            r = ''.join(_v)
+            #   v=spf1 ... ip4:157.255.1.64/29" " ip4:106.39.212.64/29 ...
+            # We should remove '" "' and combine them.
+            r = r.replace('" "', '')
 
             if r.startswith('v=spf1'):
                 spf = r


### PR DESCRIPTION
Fixes an issue with split SPF records that may start with a space, such as currently for icloud.com
```
"v=spf1 ip4:17.41.0.0/16 ip4:17.58.0.0/16 ip4:17.142.0.0/15 ip4:17.57.155.0/24 ip4:17.57.156.0/24 ip4:144.178.36.0/24 ip4:144.178.38.0/24 ip4:112.19.199.64/29 ip4:112.19.242.64/29 ip4:222.73.195.64/29 ip4:157.255.1.64/29" " ip4:106.39.212.64/29 ip4:123.126.78.64/29 ip4:183.240.219.64/29 ip4:39.156.163.64/29 ip4:57.103.64.0/18" " ip6:2a01:b747:3000:200::/56 ip6:2a01:b747:3001:200::/56 ip6:2a01:b747:3002:200::/56 ip6:2a01:b747:3003:200::/56 ip6:2a01:b747:3004:200::/56 ip6:2a01:b747:3005:200::/56 ip6:2a01:b747:3006:200::/56 ~all"
```

Before this fix, an incomplete string was returned (many addresses were missing):

```
v=spf1 ip4:17.41.0.0/16 ip4:17.58.0.0/16 ip4:17.142.0.0/15 ip4:17.57.155.0/24 ip4:17.57.156.0/24 ip4:144.178.36.0/24 ip4:144.178.38.0/24 ip4:112.19.199.64/29 ip4:112.19.242.64/29 ip4:222.73.195.64/29 ip4:157.255.1.64/29
```

After fix:
```
v=spf1 ip4:17.41.0.0/16 ip4:17.58.0.0/16 ip4:17.142.0.0/15 ip4:17.57.155.0/24 ip4:17.57.156.0/24 ip4:144.178.36.0/24 ip4:144.178.38.0/24 ip4:112.19.199.64/29 ip4:112.19.242.64/29 ip4:222.73.195.64/29 ip4:157.255.1.64/29 ip4:106.39.212.64/29 ip4:123.126.78.64/29 ip4:183.240.219.64/29 ip4:39.156.163.64/29 ip4:57.103.64.0/18 ip6:2a01:b747:3000:200::/56 ip6:2a01:b747:3001:200::/56 ip6:2a01:b747:3002:200::/56 ip6:2a01:b747:3003:200::/56 ip6:2a01:b747:3004:200::/56 ip6:2a01:b747:3005:200::/56 ip6:2a01:b747:3006:200::/56 ~all
```